### PR TITLE
Setup locales for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MIT
 
 ## Supported targets
 
-* for PXT/microbit
+* for PXT/minecraft
 (The metadata above is needed for package search.)
 
 

--- a/_locales/zh/minecraft-hoc2019-jsdoc-strings.json
+++ b/_locales/zh/minecraft-hoc2019-jsdoc-strings.json
@@ -1,0 +1,18 @@
+{
+  "hourOfCode": "Writing data for hacking stem experiments",
+  "hourOfCode.agentAnalyze": "Check for any hazards in a direction",
+  "hourOfCode.agentAnalyze|param|dir": "the direction to check for hazards",
+  "hourOfCode.agentDestroyL4": "Destroy block at level 4",
+  "hourOfCode.agentDestroyL4|param|dir": "the direction to destroy a block at",
+  "hourOfCode.agentDestroyL5": "Destroy block at level 5",
+  "hourOfCode.agentDestroyL5|param|dir": "the direction to destroy a block at",
+  "hourOfCode.agentDestroyL6": "Destroy block at level 6",
+  "hourOfCode.agentDestroyL6|param|dir": "the direction to destroy a block at",
+  "hourOfCode.agentDetectDryFern": "Detect the hazard of a dry fern",
+  "hourOfCode.agentDetectDryFern|param|dir": "the direction to detect the dry fern",
+  "hourOfCode.agentDetectDryGrass": "Detect the hazard of dry grass",
+  "hourOfCode.agentDetectDryGrass|param|dir": "the direction to detect the dry grass",
+  "hourOfCode.hazardsRemainL4": "Check for any remaining hazards on level 4",
+  "hourOfCode.hazardsRemainL5": "Check for any remaining hazards on level 5",
+  "hourOfCode.hazardsRemainL6": "Check for any remaining hazards on level 6"
+}

--- a/_locales/zh/minecraft-hoc2019-strings.json
+++ b/_locales/zh/minecraft-hoc2019-strings.json
@@ -1,0 +1,13 @@
+{
+  "hourOfCode.agentAnalyze|block": "agent analyze %dir",
+  "hourOfCode.agentDestroyL4|block": "agent destroy L4 %dir",
+  "hourOfCode.agentDestroyL5|block": "agent destroy L5 %dir",
+  "hourOfCode.agentDestroyL6|block": "agent destroy L6 %dir",
+  "hourOfCode.agentDetectDryFern|block": "agent detect dry fern %dir",
+  "hourOfCode.agentDetectDryGrass|block": "agent detect dry grass %dir",
+  "hourOfCode.hazardsRemainL4|block": "hazards remain L4",
+  "hourOfCode.hazardsRemainL5|block": "hazards remain L5",
+  "hourOfCode.hazardsRemainL6|block": "hazards remain L6",
+  "hourOfCode|block": "hourOfCode",
+  "{id:category}HourOfCode": "HourOfCode"
+}

--- a/extension.ts
+++ b/extension.ts
@@ -14,18 +14,30 @@ namespace hourOfCode {
     let completionPosition = [positions.createWorld(-75, 65, -122), positions.createWorld(-57, 57, -63), positions.createWorld(-4, 32, 199)]
     let brokeNonHazard = false
 
+    /**
+     * Detect the hazard of a dry fern
+     * @param dir the direction to detect the dry fern
+     */
     //% block="agent detect dry fern %dir"
     //% weight=80
     export function agentDetectDryFern(dir: SixDirection) {
         return agent.inspect(AgentInspection.Block, dir) == hazardA
     }
 
+    /**
+     * Detect the hazard of dry grass
+     * @param dir the direction to detect the dry grass
+     */
     //% block="agent detect dry grass %dir"
     //% weight=80
     export function agentDetectDryGrass(dir: SixDirection) {
         return agent.inspect(AgentInspection.Block, dir) == hazardB
     }
 
+    /**
+     * Check for any hazards in a direction
+     * @param dir the direction to check for hazards
+     */
     //% block="agent analyze %dir"
     //% weight=70
     export function agentAnalyze(dir: SixDirection) {
@@ -45,7 +57,10 @@ namespace hourOfCode {
         }
     }
 
-    //% block="hazards remain"
+    /**
+     * Check for any remaining hazards on level 4
+     */
+    //% block="hazards remain L4"
     //% weight=45
     export function hazardsRemainL4() {
         if (targetsL4 == 0 && !brokeNonHazard) {
@@ -53,7 +68,12 @@ namespace hourOfCode {
         }
         return targetsL4 > 0
     }
-    //% block="agent destroy %dir"
+
+    /**
+     * Destroy block at level 4
+     * @param dir the direction to destroy a block at
+     */
+    //% block="agent destroy L4 %dir"
     //% weight=40
     export function agentDestroyL4(dir: SixDirection) {
         loops.pause(500)
@@ -66,7 +86,10 @@ namespace hourOfCode {
         agent.destroy(dir)
     }
 
-    //% block="hazards remain"
+    /**
+     * Check for any remaining hazards on level 5
+     */
+    //% block="hazards remain L5"
     //% weight=55
     export function hazardsRemainL5() {
         if (targetsL5 == 0 && !brokeNonHazard) {
@@ -74,7 +97,12 @@ namespace hourOfCode {
         }
         return targetsL5 > 0
     }
-    //% block="agent destroy %dir"
+    
+    /**
+     * Destroy block at level 5
+     * @param dir the direction to destroy a block at
+     */
+    //% block="agent destroy L5 %dir"
     //% weight=50
     export function agentDestroyL5(dir: SixDirection) {
         let targetBlock5 = agent.inspect(AgentInspection.Block, dir)
@@ -86,7 +114,10 @@ namespace hourOfCode {
         agent.destroy(dir)
     }
 
-    //% block="hazards remain"
+    /**
+     * Check for any remaining hazards on level 6
+     */
+    //% block="hazards remain L6"
     //% weight=65
     export function hazardsRemainL6() {
         if (targetsL6 == 0 && !brokeNonHazard) {
@@ -94,7 +125,12 @@ namespace hourOfCode {
         }
         return targetsL6 > 0
     }
-    //% block="agent destroy %dir"
+
+    /**
+     * Destroy block at level 6
+     * @param dir the direction to destroy a block at
+     */
+    //% block="agent destroy L6 %dir"
     //% weight=60
     export function agentDestroyL6(dir: SixDirection) {
         let targetBlock6 = agent.inspect(AgentInspection.Block, dir)

--- a/pxt.json
+++ b/pxt.json
@@ -9,7 +9,9 @@
     "files": [
         "README.md",
         "extension.ts",
-        "enums.d.ts"
+        "enums.d.ts",
+        "_locales/zh/minecraft-hoc2019-strings.json",
+        "_locales/zh/minecraft-hoc2019-jsdoc-strings.json"
     ],
     "testFiles": [
         "test.ts"

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-hourOfCode.analyze(SixDirection.Forward);
+hourOfCode.agentAnalyze(SixDirection.Forward);
 hourOfCode.agentDetectDryFern(SixDirection.Forward);
 hourOfCode.agentDetectDryGrass(SixDirection.Forward);
 hourOfCode.hazardsRemainL4();


### PR DESCRIPTION
Create the locale setup for the extension.

I've patched in just one locale ``zh`` but this can be copied for the others (see [Extension localization](https://makecode.com/extensions/localization) for further details).

Review the function and parameter descriptions for accuracy as I'm not sure what's intended by the "L4, L5, L6" naming (levels I'm assuming).

Also, will need to verify that the ``zh`` code is sufficient or if ``zh-cn`` is needed to select the locale for that particular language.