### PR TITLE
[Bug 842989] [EDU] Player can't complete Scientist task in HoC2019 where Agent has to identify and destroy fire hazards

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -108,13 +108,20 @@ namespace hourOfCode {
             } else if (brokeNonHazard) {
                 return false
             }
+            // Keep testing until the next hazard appears (air means it has not)
             while (agent.inspect(AgentInspection.Block, SixDirection.Forward) == airBlock) {
-                loops.pause(100)
+                // If a hazard has not appeared, wait 6 ticks before testing again
+                for (let index = 0; index < 6; index++) {
+                  // We use testForBlock because it takes one tick (this is more reliable than waiting for X milliseconds because it's not platform dependent)
+                  blocks.testForBlock(GRASS, world(-60, 71, -90); // we're ignoring the return value since we just use this to pass time
+                }
                 if (timeout-- <= 0) {
                     return false
                 }
             }
         }
+        
+        // If we reached this point, a hazard has appeared! return true here so the student's code inside the while(hazardsRemain) can continue
         return true
     }
 

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "minecraft-hoc2019",
-    "version": "0.0.52",
+    "version": "0.0.53",
     "description": "Support for Minecraft Hour of Code activities",
     "license": "MIT",
     "dependencies": {


### PR DESCRIPTION
Posting Chris' fix for Hazards Remain to be tick-based instead of using a particular number of milliseconds. This will fix https://dev.azure.com/dev-mc/Minecraft/_workitems/edit/842989

Also added some documentation to the function for future reference.